### PR TITLE
ダメージと回復のポップアップ表示を追加

### DIFF
--- a/scripts/Entity/Actors/Components/fighter_component.gd
+++ b/scripts/Entity/Actors/Components/fighter_component.gd
@@ -38,6 +38,15 @@ func _init(_definition: FighterComponentDefinition) -> void:
     self.base_defense = _definition.base_defense
     self.base_power = _definition.base_power
 
+# ポップアップを生成して表示する処理
+#
+# @param text: 表示するテキスト
+# @param color: テキストの色
+func _show_popup(text: String, color: Color) -> void:
+    var popup: DamagePopup = DamagePopup.new(text, color)
+    entity.add_child(popup)
+
+
 # ダメージを受ける処理
 #
 # HPを減少させ、0以下になった場合の死亡ログなどを出力します。
@@ -45,6 +54,11 @@ func _init(_definition: FighterComponentDefinition) -> void:
 # @param amount: 受けるダメージ量
 func take_damage(amount: int) -> void:
     hp -= amount
+
+    # プレイヤーは赤、それ以外（敵）は白でポップアップを表示
+    var color: Color = Color.RED if entity.key == "player" else Color.WHITE
+    _show_popup(str(amount), color)
+
     Loggie.debug("Took " + str(amount) + " damage. HP: " + str(hp))
     if hp <= 0:
         hp = 0
@@ -64,7 +78,12 @@ func take_damage(amount: int) -> void:
 func heal(amount: int) -> int:
     var old_hp: int = hp
     hp += amount
-    var healed = hp - old_hp
+    var healed: int = hp - old_hp
+
+    # 回復時はマイナスで表記（色はプレイヤー/敵のルールを踏襲）
+    var color: Color = Color.RED if entity.key == "player" else Color.WHITE
+    _show_popup("-" + str(healed), color)
+
     Loggie.debug("Healed " + str(healed) + ". HP: " + str(hp))
     return healed
 

--- a/scripts/GUI/damage_popup.gd
+++ b/scripts/GUI/damage_popup.gd
@@ -1,0 +1,43 @@
+class_name DamagePopup
+extends Label
+# ダメージや回復時に表示されるポップアップのUIコンポーネント
+#
+# エンティティの頭上に数値を表示し、上方に移動しながらフェードアウトします。
+# アニメーション終了後に自身を削除します。
+
+const FONT_SIZE: int = 24
+const ANIMATION_DURATION: float = 1.0
+const MOVE_DISTANCE: float = 30.0
+
+# 初期化関数
+#
+# @param amount_text: 表示するテキスト（ダメージ量や回復量など）
+# @param color: テキストの色
+func _init(amount_text: String, color: Color) -> void:
+    text = amount_text
+    label_settings = LabelSettings.new()
+    label_settings.font_color = color
+    label_settings.font_size = FONT_SIZE
+    label_settings.outline_size = 2
+    label_settings.outline_color = Color.BLACK
+
+    # 中央揃え
+    horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+    vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+
+func _ready() -> void:
+    # 基準位置を調整（エンティティの中心やや上からスタート）
+    # pivot_offset を設定して中心基準で配置されるようにする
+    position = Vector2(-20, -20) # Spriteの中心付近から少し上にオフセット
+
+    # Tweenを作成してアニメーションを実行
+    var tween: Tween = create_tween()
+
+    # 上に移動させるアニメーション
+    tween.tween_property(self, "position:y", position.y - MOVE_DISTANCE, ANIMATION_DURATION).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
+
+    # 同時に透明度を下げてフェードアウトさせるアニメーション
+    tween.parallel().tween_property(self, "modulate:a", 0.0, ANIMATION_DURATION).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
+
+    # アニメーション終了時に自身を削除
+    tween.tween_callback(queue_free)

--- a/scripts/GUI/damage_popup.gd
+++ b/scripts/GUI/damage_popup.gd
@@ -26,9 +26,11 @@ func _init(amount_text: String, color: Color) -> void:
     vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 
 func _ready() -> void:
-    # 基準位置を調整（エンティティの中心やや上からスタート）
-    # pivot_offset を設定して中心基準で配置されるようにする
-    position = Vector2(-20, -20) # Spriteの中心付近から少し上にオフセット
+    # エンティティは32x32ピクセルで左上原点 (centered=false)
+    # ラベルの幅をタイルサイズと同じにし、中央揃えを効かせる
+    custom_minimum_size = Vector2(32, 0)
+    # 基準位置を調整（タイルの左上から、Y軸のみ上にオフセット）
+    position = Vector2(0, -20)
 
     # Tweenを作成してアニメーションを実行
     var tween: Tween = create_tween()


### PR DESCRIPTION
ダメージ発生時や回復時に、対象のエンティティ上に数値をポップアップさせる機能を追加しました。
- `DamagePopup` UIコンポーネントを新規作成し、上に移動しながらフェードアウトするアニメーション（`Tween` を使用）を実装。
- `FighterComponent` を修正し、ダメージ (`take_damage`) や回復 (`heal`) 発生時に `DamagePopup` を生成するようにしました。
- プレイヤーへのダメージは赤色、敵へのダメージは白色で表示されます。
- 回復時は数値の前にマイナス（`-`）を付与して表現しています。

---
*PR created automatically by Jules for task [4826498164839901177](https://jules.google.com/task/4826498164839901177) started by @horoama*